### PR TITLE
Add .pdbs to nuget package

### DIFF
--- a/DanSerialiser/DanSerialiser.csproj
+++ b/DanSerialiser/DanSerialiser.csproj
@@ -14,6 +14,7 @@
     <PackageTags>c#, serializer</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
This bundles the .pdb in the Nuget package so it's available for debugging.