### PR TITLE
Make ReadNextArray respect ignoreAnyInvalidTypes for unknown element types

### DIFF
--- a/DanSerialiser/DanSerialiser.csproj
+++ b/DanSerialiser/DanSerialiser.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>4.6.2.0</Version>
+    <Version>4.6.3.0</Version>
     <PackageId>DanSerialiser</PackageId>
     <PackageTitle>DanSerialiser</PackageTitle>
     <Authors>ProductiveRage</Authors>

--- a/DanSerialiser/Reflection/CachingTypeAnalyser.cs
+++ b/DanSerialiser/Reflection/CachingTypeAnalyser.cs
@@ -25,9 +25,9 @@ namespace DanSerialiser.Reflection
 		}
 
 		/// <summary>
-		/// This will throw an exception if unable to resolve the type (it will never return null)
+		/// If unable to resolve the type, this will throw an exception when ignoreAnyInvalidTypes is false; otherwise return null when it's true.
 		/// </summary>
-		public Type GetType(string typeName)
+		public Type GetType(string typeName, bool ignoreAnyInvalidTypes)
 		{
 			if (string.IsNullOrWhiteSpace(typeName))
 				throw new ArgumentException($"Null/blank {nameof(typeName)} specified");
@@ -35,7 +35,7 @@ namespace DanSerialiser.Reflection
 			if (_typeLookupCache.TryGetValue(typeName, out var cachedResult))
 				return cachedResult;
 
-			return _typeLookupCache.GetOrAdd(typeName, _reader.GetType(typeName));
+			return _typeLookupCache.GetOrAdd(typeName, _reader.GetType(typeName, ignoreAnyInvalidTypes));
 		}
 
 		public Func<object> TryToGetUninitialisedInstanceBuilder(string typeName)

--- a/DanSerialiser/Reflection/IAnalyseTypesForSerialisation.cs
+++ b/DanSerialiser/Reflection/IAnalyseTypesForSerialisation.cs
@@ -6,9 +6,9 @@ namespace DanSerialiser.Reflection
 	internal interface IAnalyseTypesForSerialisation
 	{
 		/// <summary>
-		/// This will throw an exception if unable to resolve the type (it will never return null)
+		/// If unable to resolve the type, this will throw an exception when ignoreAnyInvalidTypes is false; otherwise return null when it's true.
 		/// </summary>
-		Type GetType(string typeName);
+		Type GetType(string typeName, bool ignoreAnyInvalidTypes);
 
 		Func<object> TryToGetUninitialisedInstanceBuilder(string typeName);
 		Tuple<MemberAndReader<FieldInfo>[], MemberAndReader<PropertyInfo>[]> GetFieldsAndProperties(Type type);

--- a/DanSerialiser/Reflection/ReflectionTypeAnalyser.cs
+++ b/DanSerialiser/Reflection/ReflectionTypeAnalyser.cs
@@ -16,9 +16,9 @@ namespace DanSerialiser.Reflection
 		private ReflectionTypeAnalyser() { }
 
 		/// <summary>
-		/// This will throw an exception if unable to resolve the type (it will never return null)
+		/// If unable to resolve the type, this will throw an exception when ignoreAnyInvalidTypes is false; otherwise return null when it's true.
 		/// </summary>
-		public Type GetType(string typeName)
+		public Type GetType(string typeName, bool ignoreAnyInvalidTypes)
 		{
 			if (string.IsNullOrWhiteSpace(typeName))
 				throw new ArgumentException($"Null/blank {nameof(typeName)} specified");
@@ -27,7 +27,7 @@ namespace DanSerialiser.Reflection
 			// the processing time (it was particularly noticeable one time and less so others.. I'm not sure why) and so IAnalyseTypesForSerialisation has a GetType method
 			// so that the caching implementation of it can avoid the repeated Type.GetType calls (http://higherlogics.blogspot.com/2010/05/cost-of-typegettype.html suggests
 			// that I'm not the only one to have noticed this!)
-			return Type.GetType(typeName, throwOnError: true);
+			return Type.GetType(typeName, throwOnError: !ignoreAnyInvalidTypes);
 		}
 
 		public Func<object> TryToGetUninitialisedInstanceBuilder(string typeName)


### PR DESCRIPTION
This commit makes it so that if `ReadNextArray` is called with `ignoreAnyInvalidTypes: true`, it will now pass that flag into the `IAnalyseTypesForSerialisation.GetType` method which it calls to get the array's element type. This ensures that if we're reading some unknown data that we want to ignore, it won't fail if the array element type is not known.

When the element type is not known (and `ignoreAnyInvalidTypes` is `true`), `ReadNextArray` will now avoid building up an actual `Array` instance with elements, and will instead just return null at the end (once it's exhausted all the unknown content within the array).

Without this change, if we were to add a new array field/property to an object, whose element type was unknown, we would encounter an error. For example:

![Error: Could not load type 'NewMind.Tourism.DataServices.Base.Products.Product+SpecialOfferDetails' from assembly 'NewMind.Tourism.DataServices.Base, Version=1.0.1.0, Culture=neutral, PublicKeyToken=null.'](https://user-images.githubusercontent.com/844245/122419938-331aec80-cf83-11eb-99d4-7bb769f6a4ab.png)

This error would happen when adding a new `public KeyedList<SpecialOfferDetails> SpecialOffers { get; set; }` property to a base `Product` class. The `SpecialOfferDetails` class is a new type that the client is unaware about, but should be being ignored since it doesn't know about this new field in its own version of the type anyway.

Adding the logic in this pull request means that clients are able to skip over unknown fields that contain arrays of unknown element types without any errors.

---

The unit test `DoNotThrowWhenTryingToParseUnavailableArrayElementTypeIfThereIsNoFieldThatTheTypeWouldBeUsedToSet` in commit 0e867cf54bc1b2afcb94c3e642a629106d3083b5 can be tested before and after the code fix. It should fail before the change, and succeed after the change.